### PR TITLE
Update appdirs to version 1.4.3.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-appdirs==1.4.2
+appdirs==1.4.3
 beautifulsoup4==4.5.3
 bleach==1.5.0
 boto3==1.4.4


### PR DESCRIPTION
Local installation fails due to version `1.4.2`. The upgrade solved the issue locally. More info can be found here [0].

[0] https://github.com/ActiveState/appdirs/issues/89