### PR TITLE
Remove  check from admin user creation.

### DIFF
--- a/coss/users/forms.py
+++ b/coss/users/forms.py
@@ -51,7 +51,7 @@ class CossUserCreationForm(UserCreationForm):
         error_msg = ''
 
         # Do not allow non-admin accounts with an empty site entry
-        if (not cdata.get('is_superuser') or not cdata.get('is_staff')) and not cdata.get('site'):
+        if not cdata.get('is_superuser') and not cdata.get('site'):
             # raise ValidationError('You need to associate this account with a site.')
             error_msg = 'You need to associate this account with a site.'
 


### PR DESCRIPTION
@comzeradd quick r?
The `is_staff` flag is never passed from the form to the clean method. This has as a result that the `or` statement is validated as `True` for the creation of an administrator when it should be False.