### PR TITLE
Simplify compress tags

### DIFF
--- a/coss/home/templates/home/about_page.html
+++ b/coss/home/templates/home/about_page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static compress wagtailcore_tags %}
+{% load static wagtailcore_tags %}
 
 {% block body_class %}about{% endblock %}
 
@@ -46,8 +46,6 @@
   </div>
 {% endblock %}
 
-{% compress js %}
-  {% block extra_js %}
-    <script type="text/javascript" src="{% static 'js/clubs_about.js' %}"></script>
-  {% endblock %}
-{% endcompress %}
+{% block extra_js %}
+  <script type="text/javascript" src="{% static 'js/clubs_about.js' %}"></script>
+{% endblock %}

--- a/coss/opensource_clubs/templates/opensource_clubs/about_page.html
+++ b/coss/opensource_clubs/templates/opensource_clubs/about_page.html
@@ -1,12 +1,10 @@
 {% extends "home/about_page.html" %}
-{% load static compress wagtailcore_tags %}
+{% load static wagtailcore_tags %}
 
-{% compress css %}
-  {% block extra_css %}
-    <link rel="stylesheet" type="text/css" href="{% static 'css/clubs.css' %}">
-    <link rel="stylesheet" type="text/css" href="{% static 'css/about.css' %}">
-  {% endblock %}
-{% endcompress %}
+{% block extra_css %}
+  <link rel="stylesheet" type="text/css" href="{% static 'css/clubs.css' %}">
+  <link rel="stylesheet" type="text/css" href="{% static 'css/about.css' %}">
+{% endblock %}
 
 {% block brand-logo %}
   <img src="{% static 'img/mozilla-clubs-white.svg' %}" alt="mozilla">
@@ -47,8 +45,6 @@
   </div>
 {% endblock %}
 
-{% compress js %}
-  {% block extra_js %}
-    <script type="text/javascript" src="{% static 'js/clubs_about.js' %}"></script>
-  {% endblock %}
-{% endcompress %}
+{% block extra_js %}
+  <script type="text/javascript" src="{% static 'js/clubs_about.js' %}"></script>
+{% endblock %}

--- a/coss/opensource_clubs/templates/opensource_clubs/category_base.html
+++ b/coss/opensource_clubs/templates/opensource_clubs/category_base.html
@@ -1,11 +1,9 @@
 {% extends "base.html" %}
-{% load static compress %}
+{% load static %}
 
-{% compress css %}
-  {% block extra_css %}
-    <link rel="stylesheet" type="text/css" href="{% static 'css/clubs.css' %}">
-  {% endblock %}
-{% endcompress %}
+{% block extra_css %}
+  <link rel="stylesheet" type="text/css" href="{% static 'css/clubs.css' %}">
+{% endblock %}
 
 {% block brand-logo %}
   <img src="{% static 'img/mozilla-clubs-black.svg' %}" alt="mozilla">

--- a/coss/opensource_clubs/templates/opensource_clubs/entity_detail_page.html
+++ b/coss/opensource_clubs/templates/opensource_clubs/entity_detail_page.html
@@ -1,12 +1,10 @@
 {% extends "opensource_clubs/category_base.html" %}
-{% load static compress wagtailcore_tags wagtailimages_tags %}
+{% load static wagtailcore_tags wagtailimages_tags %}
 
-{% compress css %}
-  {% block extra_css %}
-    {{ block.super }}
-    <link rel="stylesheet" type="text/css" href="{% static 'css/entity.css' %}">
-  {% endblock %}
-{% endcompress %}
+{% block extra_css %}
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css" href="{% static 'css/entity.css' %}">
+{% endblock %}
 
 {% block body_class %}entity{% endblock %}
 

--- a/coss/settings.py
+++ b/coss/settings.py
@@ -130,6 +130,10 @@ STATICFILES_FINDERS = [
 COMPRESS_ENABLED = config('COMPRESS_ENABLED', default=True, cast=bool)
 COMPRESS_OFFLINE = config('COMPRESS_OFFLINE', default=True, cast=bool)
 COMPRESS_CACHE_BACKEND = config('COMPRESS_CACHE_BACKEND', default='default')
+COMPRESS_CSS_FILTERS = [
+    'compressor.filters.css_default.CssAbsoluteFilter',
+    'compressor.filters.cssmin.rCSSMinFilter'
+]
 
 #######################
 # Environment Variables


### PR DESCRIPTION
I simplified the way we use the compressor. Extra blocks are already process being part of the compress tag on the base template. This way we produce one file per template, instead of separate.

I also added `rCSSMinFilter` support. According to the [docs](http://django-compressor.readthedocs.io/en/latest/settings/#backend-settings), by default compressor only uses `CssAbsoluteFilter` for css.