### PR TITLE
Add Google site verification

### DIFF
--- a/coss/base/templates/base.html
+++ b/coss/base/templates/base.html
@@ -6,6 +6,7 @@
   <head>
     <meta http-equiv="Content-type" content="text/html; charset=utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="google-site-verification" content="EC15_VrYwUHPZ4kIxgTjJL4ARJoXu0fz3L5h62lGpH8">
 
     {% compress js %}
       <script type="text/javascript" src="{% static 'lib/dnt-helper/js/dnt-helper.js' %}"></script>


### PR DESCRIPTION
Added a key for verifying website ownership needed for advanced Google analytics and private search data.