### PR TITLE
Don't use variables on footer height

### DIFF
--- a/coss/home/static/css/_components.scss
+++ b/coss/home/static/css/_components.scss
@@ -407,8 +407,12 @@ footer {
     background: black;
     color: white;
     display: block;
-    height: var(--footer-height);
+    height: 170px;
     padding: 35px;
+
+    @media (max-width: 575px) {
+        height: 300px;
+    }
 
     .icon-container {
         display: inline-block;

--- a/coss/home/static/css/_variables.scss
+++ b/coss/home/static/css/_variables.scss
@@ -12,10 +12,4 @@
     --input-bg-color: #446776;
 
     --nav-link-color: black;
-
-    --footer-height: 170px;
-
-    @media (max-width: 575px) {
-        --footer-height: 300px;
-    }
 }

--- a/coss/home/static/css/coss.scss
+++ b/coss/home/static/css/coss.scss
@@ -17,13 +17,21 @@ body {
 }
 
 .page-wrap {
-    margin-bottom: calc(var(--footer-height) * -1);
+    margin-bottom: -170px;
     min-height: 100%;
+
+    @media (max-width: 575px) {
+        margin-bottom: -300px;
+    }
 
     &:after {
         content: '';
         display: block;
-        height: var(--footer-height);
+        height: 170px;
+
+        @media (max-width: 575px) {
+            height: 300px;
+        }
     }
 }
 


### PR DESCRIPTION
This fixes the sticky footer on Edge since it doesn't support variables calculations.

Related issue: #490 